### PR TITLE
iOS 최소 지원버전 11->12 상향시 Deprecated Method 대응 관련

### DIFF
--- a/Sources/RBBomReaderEngine/RBBomNodeInfo.m
+++ b/Sources/RBBomReaderEngine/RBBomNodeInfo.m
@@ -68,4 +68,8 @@
     _rawOffset += delta;
 }
 
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
 @end

--- a/Sources/RBBomReaderEngine/include/RBBomNodeInfo.h
+++ b/Sources/RBBomReaderEngine/include/RBBomNodeInfo.h
@@ -10,7 +10,7 @@
 
 @class RBBomTagNode;
 
-@interface RBBomNodeInfo : NSObject <RBBomLocation, NSCoding>
+@interface RBBomNodeInfo : NSObject <RBBomLocation, NSCoding, NSSecureCoding>
 
 @property (nonatomic, readonly) NSInteger nodeIndex;
 @property (nonatomic) NSInteger offset;


### PR DESCRIPTION
## 작업 내역

- RBBomNodeInfo Class가 [NSSecureCoding](https://developer.apple.com/documentation/foundation/nssecurecoding) 프로토콜을 채택하도록 수정했습니다.
- NSSecureCoding 프로토콜 채택시 필요한 stub([supportsSecureCoding](https://developer.apple.com/documentation/foundation/nssecurecoding/1855946-supportssecurecoding))을 적용했습니다.

## 참고사항
- iOS 12이후부터 기존에 unarchive시 사용하던 [unarchiveObject(with:)](https://developer.apple.com/documentation/foundation/nskeyedunarchiver/1413894-unarchiveobject) 가 Deprecated됩니다.
- 이에 따른 대응으로 unarchive시 [unarchivedObject(ofClasses:from:)](https://developer.apple.com/documentation/foundation/nskeyedunarchiver/2962885-unarchivedobject)를 사용하도록 수정이 필요합니다.
- `Bom Viewer`의 페이지 로딩시, `readPageIndexFile`에서 `pageLocations`가 `[RBBomNodeInfo]` 타입으로, `unarchivedObject`를 통해 unarchive시 정상적으로 decode 되기 위해서는 RBBomNodeInfo가 NSSecureCoding 프로토콜을 채택해야해서 수정하였습니다.